### PR TITLE
Don't let pep8 wander into .tox directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docs:
 	cd doc && make html
 
 quality:
-	pep8
+	pep8 --exclude=.tox
 	script/max_pylint_violations
 
 package:


### PR DESCRIPTION
I think this will fix your travis builds.
